### PR TITLE
Add queue-game cli call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,6 +2067,7 @@ dependencies = [
  "ita-stf",
  "itc-rpc-client",
  "itp-node-api-extensions",
+ "itp-registry-storage",
  "itp-types",
  "json",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,5 +42,6 @@ sp-core = { version = "5.0.0", git = "https://github.com/paritytech/substrate.gi
 #local dependencies
 itp-types = { path = "../core-primitives/types" }
 itp-node-api-extensions = { path = "../core-primitives/node-api-extensions" }
+itp-registry-storage = { path = "../core-primitives/registry-storage" }
 ita-stf = { path = "../app-libs/stf" }
 itc-rpc-client = { path = "../core/rpc-client" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -445,7 +445,10 @@ fn main() {
 
 					let tx_hash =
 						chain_api.send_extrinsic(xt.hex_encode(), XtStatus::InBlock).unwrap();
-					println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
+					println!(
+						"[+] Successfully registered player in game queue. Extrinsic Hash: {:?}\n",
+						tx_hash
+					);
 					Ok(())
 				}),
 		)

--- a/core-primitives/registry-storage/src/lib.rs
+++ b/core-primitives/registry-storage/src/lib.rs
@@ -5,6 +5,8 @@ use sp_std::prelude::Vec;
 
 use itp_storage::{storage_map_key, StorageHasher};
 
+pub const REGISTRY: &str = "GameRegistry";
+
 pub struct RegistryStorage;
 
 // Separate the prefix from the rest because in our case we changed the storage prefix due to
@@ -17,7 +19,7 @@ pub trait StoragePrefix {
 
 impl StoragePrefix for RegistryStorage {
 	fn prefix() -> &'static str {
-		"Registry"
+		REGISTRY
 	}
 }
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -371,7 +371,7 @@ fn start_worker<E, T, D>(
 	}
 
 	println!("[>] Register the enclave (send the extrinsic)");
-	let register_enclave_xt_hash = node_api.send_extrinsic(xthex, XtStatus::InBlock).unwrap();
+	let register_enclave_xt_hash = node_api.send_extrinsic(xthex, XtStatus::Finalized).unwrap();
 	println!("[<] Extrinsic got finalized. Hash: {:?}\n", register_enclave_xt_hash);
 
 	let last_synced_header = init_light_client(&node_api, enclave.clone()).unwrap();


### PR DESCRIPTION
Reverts #18 and adds the cli command
` ./integritee-cli -p 9994 queue-game //Alice`

a new player can now be registered to join a game queue.

Example:
```
~/worker/bin$ ./integritee-cli -p 9994 queue-game //Bob
[+] Successfully registered player in game queue. Extrinsic Hash: Some(0x255f18b7ae37f78a43e6d5451f7efd6307dc76e42034154a3c53a23e4eb74a9f)
```