### PR TITLE
State of the board isn't cleared until finish_game is called

### DIFF
--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -158,6 +158,7 @@ pub fn ensure_root(account: AccountId) -> StfResult<()> {
 }
 
 pub fn get_board_for(who: AccountId) -> Option<SgxGuessingBoardStruct> {
+	std::println!("get board for: {:?}", who.clone());
 	if let Some(board_id) = get_storage_map::<AccountId, SgxBoardId>(
 		"AjunaBoard",
 		"PlayerBoards",
@@ -170,18 +171,22 @@ pub fn get_board_for(who: AccountId) -> Option<SgxGuessingBoardStruct> {
 			&board_id,
 			&StorageHasher::Identity,
 		) {
+			std::println!("FOUND BOARD {}", board_id);
 			Some(board)
 		} else {
+			std::println!("COULD NOT READ BOARD");
 			debug!("could not read board");
 			None
 		}
 	} else {
+		std::println!("NOT VALID BOARD ID");
 		debug!("could not read board id");
 		None
 	}
 }
 
 pub fn is_winner(who: AccountId) -> Option<SgxWinningBoard> {
+	std::println!("is_winner");
 	if let Some(board_id) = get_storage_map::<AccountId, SgxBoardId>(
 		"AjunaBoard",
 		"PlayerBoards",
@@ -201,11 +206,17 @@ pub fn is_winner(who: AccountId) -> Option<SgxWinningBoard> {
 					&board_id,
 					&StorageHasher::Identity,
 				) {
+					std::println!("Board winner found {:?}", who);
 					return Some(SgxWinningBoard { winner, board_id })
 				}
+			} else {
+				std::println!("board winner found but not {:?} as it is {:?}", who, winner);
 			}
+		} else {
+			std::println!("No winner for board id {:?}", board_id);
 		}
 	} else {
+		std::println!("INVALID BOARD ID for is_winner");
 		debug!("could not read board id");
 	}
 

--- a/cli/src/trusted_commands.rs
+++ b/cli/src/trusted_commands.rs
@@ -285,23 +285,12 @@ fn get_board(cli: &Cli, trusted_args: &TrustedArgs, arg_player: &str) {
 	let res = perform_operation(cli, trusted_args, &top);
 	debug!("received result for board");
 	if let Some(v) = res {
-		if let Ok(_board) = SgxGuessingBoardStruct::decode(&mut v.as_slice()) {
-			// println!("Last turn in block number: {}", board.last_turn);
-			// println!("Next player: {}", board.next_player);
-			// println!("Board state: {:?}", board.board_state);
-			// println!("Board:");
-			// for row in 0..6 {
-			// 	for column in 0..7 {
-			// 		print!(" {} ", board.board[column][row]);
-			// 	}
-			// 	println!()
-			// }
-			// println!("=====================");
-			// for column in 0..7 {
-			// 	print!(" {} ", column);
-			// }
-			// println!();
-			println!("Decode board successfully");
+		if let Ok(board) = SgxGuessingBoardStruct::decode(&mut v.as_slice()) {
+			println!("Solution: {}", board.state.solution);
+			println!("Players: {:?}", board.state.players);
+			println!("Next player: {}", board.state.next_player);
+			println!("Winner: {:?}", board.state.winner);
+			println!();
 		} else {
 			println!("could not decode board. maybe hasn't been set? {:x?}", v);
 		}

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -99,6 +99,7 @@ where
 	{
 		let (_call, games, shard) = &xt.function;
 
+		std::println!("handle_ack_game");
 		info!("found {:?} games", games.len());
 
 		for game in games {
@@ -116,6 +117,7 @@ where
 		ParentchainBlock: ParentchainBlockTrait<Hash = H256>,
 	{
 		let (_call, game_id, _winner, shard) = &xt.function;
+		std::println!("handle_finish_game");
 
 		info!("handle finish game {}", game_id);
 
@@ -176,6 +178,7 @@ where
 				UncheckedExtrinsicV4::<FinishGameFn>::decode(&mut xt_opaque.encode().as_slice())
 			{
 				if xt.function.0 == [GAME_REGISTRY_MODULE, FINISH_GAME] {
+					std::println!("Finish game xt found!!!!!!!!!!!!!");
 					if let Err(e) = self.handle_finish_game_xt(&xt, block) {
 						error!("Error performing finish game. Error: {:?}", e);
 					} else {

--- a/sidechain/consensus/aura/src/block_importer.rs
+++ b/sidechain/consensus/aura/src/block_importer.rs
@@ -210,6 +210,7 @@ impl<
 		call: &TrustedCallSigned,
 	) -> Result<Option<SgxWinningBoard>, ConsensusError> {
 		let shard = &sidechain_block.header().shard_id();
+		std::println!("get_board_if_game_finished");
 		if let TrustedCall::board_play_turn(account, _b) = &call.call {
 			let mut state = self
 				.state_handler
@@ -220,6 +221,8 @@ impl<
 			} else {
 				error!("could not decode board. maybe hasn't been set?");
 			}
+		} else {
+			std::println!("not board play xt");
 		}
 		Ok(None)
 	}
@@ -229,6 +232,9 @@ impl<
 		sidechain_block: &SignedSidechainBlock::Block,
 		winning_board: SgxWinningBoard,
 	) -> Result<(), ConsensusError> {
+
+		std::println!("send_game_finished_extrinsic");
+
 		let shard = &sidechain_block.header().shard_id();
 
 		let opaque_call = OpaqueCall::from_tuple(&(


### PR DESCRIPTION
This is a workaround for L2 as we need to maintain the board state and the players in the game until we have finalised the finish game on L1.  Probably a better way to do this but the design of the L2 forces this.